### PR TITLE
FINALLY figured out what was causing the optimization count to be wro…

### DIFF
--- a/experiment_config.cfg
+++ b/experiment_config.cfg
@@ -2,8 +2,8 @@
 # General settings
 
 set SEED -1                # Random number seed (-1 to use current time)
-set TREATMENT 1            # 0 for Reduced Lexicase,  1 for Cohort Lexicase,  2 for Downsampled Lexicase  3 for Truncated Lexicase
-set POP_SIZE 1000          # The size of our evolving population
+set TREATMENT 0            # 0 for Reduced Lexicase,  1 for Cohort Lexicase,  2 for Downsampled Lexicase  3 for Truncated Lexicase
+set POP_SIZE 10          # The size of our evolving population
 set GENERATIONS 3000        # The number of generations to simulate
 set DILUTION_PCT 0.000000  # The percentage of tests that will be auto-pass (non-discriminatory)
 set TERMINATE_ON_FOUND 1   # If 1, program will terminate as soon as the first solution is found.

--- a/src/experiment/experiment.h
+++ b/src/experiment/experiment.h
@@ -884,7 +884,7 @@ void Experiment::Evaluate(){
 void Experiment::Select(){
     switch(treatment_type){
         case REDUCED_LEXICASE: {
-            emp::LexicaseSelectWORKAROUND(*world,
+            emp::LexicaseSelect(*world,
                                 lexicase_fit_funcs, 
                                 POP_SIZE,
                                 LEXICASE_MAX_FUNCS);
@@ -913,14 +913,14 @@ void Experiment::Select(){
             break;
         }
         case DOWNSAMPLED_LEXICASE: {
-            emp::LexicaseSelectWORKAROUND(*world,
+            emp::LexicaseSelect(*world,
                                 lexicase_fit_funcs, 
                                 POP_SIZE,
                                 DOWNSAMPLED_MAX_FUNCS);
             break;
         }
         case TRUNCATED_LEXICASE: {
-            emp::LexicaseSelectWORKAROUND(*world,
+            emp::LexicaseSelect(*world,
                                 lexicase_fit_funcs, 
                                 POP_SIZE,
                                 TRUNCATED_MAX_FUNCS);


### PR DESCRIPTION
…ng. LexicaseSelect was cacheing all fitness values, which in turn caused my hack-y solution to artificially (but not really) inflate the evaluation count.